### PR TITLE
Adding test to check whether overflow flag is set correctly on left shift

### DIFF
--- a/examples/software/bmark/vbw_vec_shl_t/Makefile
+++ b/examples/software/bmark/vbw_vec_shl_t/Makefile
@@ -1,0 +1,1 @@
+include ../common/Makefile

--- a/examples/software/bmark/vbw_vec_shl_t/sources.mk
+++ b/examples/software/bmark/vbw_vec_shl_t/sources.mk
@@ -1,0 +1,1 @@
+C_SRCS += test.c

--- a/examples/software/bmark/vbw_vec_shl_t/test.c
+++ b/examples/software/bmark/vbw_vec_shl_t/test.c
@@ -1,0 +1,134 @@
+/* VECTORBLOX MXP SOFTWARE DEVELOPMENT KIT
+ *
+ * Copyright (C) 2012-2018 VectorBlox Computing Inc., Vancouver, British Columbia, Canada.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the name of VectorBlox Computing Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This agreement shall be governed in all respects by the laws of the Province
+ * of British Columbia and by the laws of Canada.
+ *
+ * This file is part of the VectorBlox MXP Software Development Kit.
+ *
+ */
+
+
+#include "vbx_copyright.h"
+VBXCOPYRIGHT( test_vec_shl )
+
+/*
+ * Vector Add - Scalar version and Vector version
+ */
+
+#include <stdio.h>
+#include "vbx.h"
+#include "vbx_test.h"
+#include "scalar_vec_shl.h"
+#include "vbw_vec_shl.h"
+
+#define VBX_TEMPLATE_T   VBX_UBYTESIZE_DEF
+// signed   VBX_BYTESIZE_DEF    VBX_HALFSIZE_DEF    VBX_WORDSIZE_DEF
+// unsigned VBX_UBYTESIZE_DEF   VBX_UHALFSIZE_DEF   VBX_UWORDSIZE_DEF
+#include "vbw_template_t.h"
+
+int test_vector( vbx_sp_t *v_out, vbx_sp_t *v_in, int N)
+{
+	int retval;
+
+	printf( "\nExecuting MXP vector overflow test...\n" );
+
+	retval = VBX_T(vbw_vec_shl)( v_out, v_in, N );
+	vbx_sync();
+
+	printf( "...done. retval: %X\n", retval );
+	return retval;
+}
+
+
+int test_scalar( vbx_mm_t *scalar_out, vbx_mm_t *scalar_in, int N )
+{
+	printf( "\nExecuting scalar shift overflow test...\n" );
+
+	VBX_T(scalar_vec_shl)( scalar_out, scalar_in, N );
+
+	printf( "...done\n" );
+	return 0;
+}
+
+int main(void)
+{
+	vbx_test_init();
+	vbx_mxp_t *this_mxp = VBX_GET_THIS_MXP();
+	const int VBX_SCRATCHPAD_SIZE = this_mxp->scratchpad_size;
+	const int required_vectors = 4;
+
+	int N = VBX_SCRATCHPAD_SIZE / sizeof(vbx_mm_t) / required_vectors;
+
+	int PRINT_LENGTH = N< MAX_PRINT_LENGTH ? N:MAX_PRINT_LENGTH;
+
+	double scalar_time;
+	int errors=0;
+
+	vbx_mxp_print_params();
+	printf( "\nShift overflow test...\n" );
+	printf( "Vector length: %d\n", N );
+
+	vbx_mm_t *scalar_in = malloc( N*sizeof(vbx_mm_t) );
+	vbx_mm_t *scalar_out = malloc( N*sizeof(vbx_mm_t) );
+
+	vbx_mm_t *vector_in = vbx_shared_malloc( N*sizeof(vbx_mm_t) );
+	vbx_mm_t *vector_out = vbx_shared_malloc( N*sizeof(vbx_mm_t) );
+
+	vbx_sp_t *v_in = vbx_sp_malloc( N*sizeof(vbx_sp_t) );
+	vbx_sp_t *v_out = vbx_sp_malloc( N*sizeof(vbx_sp_t) );
+
+	VBX_T(test_zero_array)( scalar_out, N );
+	VBX_T(test_zero_array)( vector_out, N );
+
+	VBX_T(test_init_array)( scalar_in, N, 1 );
+	VBX_T(test_copy_array)( vector_in, scalar_in, N );
+
+	VBX_T(test_print_array)( scalar_in, PRINT_LENGTH );
+
+	scalar_time = test_scalar( scalar_out, scalar_in, N );
+	VBX_T(test_print_array)( scalar_out, PRINT_LENGTH);
+
+	vbx_dma_to_vector( v_in, (void *)vector_in, N*sizeof(vbx_sp_t) );
+	test_vector( v_out, v_in, N );
+	vbx_dma_to_host( (void *)vector_out, v_out, N*sizeof(vbx_sp_t) );
+	vbx_sync();
+	VBX_T(test_print_array)( vector_out, PRINT_LENGTH );
+
+	errors += VBX_T(test_verify_array)( scalar_out, vector_out, N );
+
+	vbx_shared_free(vector_in);
+	vbx_shared_free(vector_out);
+	free(scalar_in);
+	free(scalar_out);
+
+	VBX_TEST_END(errors);
+	return 0;
+}

--- a/examples/software/bmark/vbw_vec_shl_t/test.c
+++ b/examples/software/bmark/vbw_vec_shl_t/test.c
@@ -1,46 +1,5 @@
-/* VECTORBLOX MXP SOFTWARE DEVELOPMENT KIT
- *
- * Copyright (C) 2012-2018 VectorBlox Computing Inc., Vancouver, British Columbia, Canada.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *
- *     * Neither the name of VectorBlox Computing Inc. nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- * This agreement shall be governed in all respects by the laws of the Province
- * of British Columbia and by the laws of Canada.
- *
- * This file is part of the VectorBlox MXP Software Development Kit.
- *
- */
-
-
-#include "vbx_copyright.h"
-VBXCOPYRIGHT( test_vec_shl )
-
 /*
- * Vector Add - Scalar version and Vector version
+ * Vector Left Shift - Scalar version and Vector version
  */
 
 #include <stdio.h>

--- a/examples/software/lib/scalar/scalar_vec_shl.c
+++ b/examples/software/lib/scalar/scalar_vec_shl.c
@@ -1,0 +1,117 @@
+#include "scalar_vec_shl.h"
+
+void scalar_vec_shl_byte(int8_t *output, int8_t *input, const int32_t N){
+    int32_t i, j;
+    uint8_t m1, m2;
+    for (i = 0; i < N; i++) {
+    	m1 = 1 << 6;
+    	m2 = 1 << 7;
+
+	    for(j = 1; j < 8; j++) {
+	    	// If the indices around the shift point are different, an overflow should be triggered
+	    	uint8_t bit1 = (input[i] & m1) << 1;
+			uint8_t bit2 = (input[i] & m2);
+	        if (bit1 ^ bit2) {
+	        	output[i] = j;
+	        	break;
+	        }
+	        m1 >>= 1;
+	        m2 >>= 1;
+	    }
+	    if (input[i] < 0 && output[i] == 0)	output[i] = 8;
+	}
+}
+
+void scalar_vec_shl_half(int16_t *output, int16_t *input, const int32_t N){
+    int32_t i, j;
+    uint16_t m1, m2;
+    for (i = 0; i < N; i++) {
+    	m1 = 1 << 14;
+    	m2 = 1 << 15;
+	    for(j = 1; j < 16; j++) {
+	    	// If the indices around the shift point are different, an overflow should be triggered
+	    	uint16_t bit1 = (input[i] & m1) << 1;
+			uint16_t bit2 = (input[i] & m2);
+	        if (bit1 ^ bit2) {
+	        	output[i] = j;
+	        	break;
+	        }
+	        m1 >>= 1;
+	        m2 >>= 1;
+	    }
+	    if (input[i] < 0 && output[i] == 0)	output[i] = 16;
+	}
+}
+
+void scalar_vec_shl_word(int32_t *output, int32_t *input, const int32_t N){
+    int32_t i, j;
+    uint32_t m1, m2;
+    for (i = 0; i < N; i++) {
+    	m1 = 1 << 30;
+    	m2 = 1 << 31;
+	    for(j = 1; j < 32; j++) {
+	    	// If the indices around the shift point are different, an overflow should be triggered
+	    	uint32_t bit1 = (input[i] & m1) << 1;
+			uint32_t bit2 = (input[i] & m2);
+	        if (bit1 ^ bit2) {
+	        	output[i] = j;
+	        	break;
+	        }
+	        m1 >>= 1;
+	        m2 >>= 1;
+	    }
+	    if (input[i] < 0 && output[i] == 0)	output[i] = 32;
+	}
+}
+
+// Unsigned we can just check if a bit is set, no need for the bits to flip.
+void scalar_vec_shl_ubyte(uint8_t *output, uint8_t *input, const int32_t N){
+    int32_t i, j;
+    uint8_t m1;
+    for (i = 0; i < N; i++) {
+    	m1 = 1 << 7;
+
+	    for(j = 1; j <= 8; j++) {
+	    	// If the index at the shift point is high, an overflow should be triggered
+	    	if (input[i] & m1) {
+	        	output[i] = j;
+	        	break;
+	        }
+	        m1 >>= 1;
+	    }
+	}
+}
+
+void scalar_vec_shl_uhalf(uint16_t *output, uint16_t *input, const int32_t N){
+    int32_t i, j;
+    uint16_t m1;
+    for (i = 0; i < N; i++) {
+    	m1 = 1 << 15;
+
+	    for(j = 1; j <= 16; j++) {
+	    	// If the index at the shift point is high, an overflow should be triggered
+	    	if (input[i] & m1) {
+	        	output[i] = j;
+	        	break;
+	        }
+	        m1 >>= 1;
+	    }
+	}
+}
+
+void scalar_vec_shl_uword(uint32_t *output, uint32_t *input, const int32_t N){
+    int32_t i, j;
+    uint32_t m1;
+    for (i = 0; i < N; i++) {
+    	m1 = 1 << 31;
+
+	    for(j = 1; j <= 32; j++) {
+	    	// If the index at the shift point is high, an overflow should be triggered
+	    	if (input[i] & m1) {
+	        	output[i] = j;
+	        	break;
+	        }
+	        m1 >>= 1;
+	    }
+	}
+}

--- a/examples/software/lib/scalar/scalar_vec_shl.h
+++ b/examples/software/lib/scalar/scalar_vec_shl.h
@@ -1,0 +1,18 @@
+#ifndef SCALAR_VEC_SHL_H
+#define SCALAR_VEC_SHL_H
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void scalar_vec_shl_over_byte(int8_t *output, int8_t *input, const int32_t N);
+void scalar_vec_shl_half(int16_t *output, int16_t *input, const int32_t N);
+void scalar_vec_shl_word(int32_t *output, int32_t *input, const int32_t N);
+void scalar_vec_shl_ubyte(uint8_t *output, uint8_t *input, const int32_t N);
+void scalar_vec_shl_uhalf(uint16_t *output, uint16_t *input, const int32_t N);
+void scalar_vec_shl_uword(uint32_t *output, uint32_t *input, const int32_t N);
+
+#ifdef __cplusplus
+}
+#endif
+#endif //VBW_VEC_ADD_H

--- a/examples/software/lib/scalar/sources.mk
+++ b/examples/software/lib/scalar/sources.mk
@@ -11,3 +11,4 @@ C_SRCS += scalar_vec_rev.c
 C_SRCS += scalar_vec_add.c
 C_SRCS += scalar_vec_divide.c
 C_SRCS += scalar_vec_power.c
+C_SRCS += scalar_vec_shl.c

--- a/examples/software/lib/vbxware/sources.mk
+++ b/examples/software/lib/vbxware/sources.mk
@@ -38,3 +38,5 @@ CXX_SRCS += vbw_vec_div.cpp
 CXX_SRCS += vbw_mtx_xp.cpp
 CXX_SRCS += vbw_vec_add.cpp
 CXX_SRCS += vbw_vec_fir.cpp
+
+CXX_SRCS += vbw_vec_shl.cpp

--- a/examples/software/lib/vbxware/vbw_vec_shl.cpp
+++ b/examples/software/lib/vbxware/vbw_vec_shl.cpp
@@ -11,7 +11,7 @@ int vbw_vec_shl(vbx_sp_t *v_out, vbx_sp_t *v_in, unsigned int vl)
 	// zero the output and temp
 	vbxx(VMOV, v_out, 0);
 
-	for (int i = 1; i < 8*sizeof(vbx_sp_t); i++){
+	for (int i = 1; i <= 8*sizeof(vbx_sp_t); i++){
 		vbxx(VSHL, v_temp, v_in, i);
 
 		// set v_out to the index at which it overflows

--- a/examples/software/lib/vbxware/vbw_vec_shl.cpp
+++ b/examples/software/lib/vbxware/vbw_vec_shl.cpp
@@ -1,0 +1,44 @@
+#include "vbx.h"
+#include "vbw_exit_codes.h"
+
+template<typename vbx_sp_t>
+int vbw_vec_shl(vbx_sp_t *v_out, vbx_sp_t *v_in, unsigned int vl)
+{
+	vbx_sp_t *v_temp = (vbx_sp_t *)vbx_sp_malloc(sizeof(vbx_sp_t)*vl);
+
+	vbx_set_vl(vl,1,1);
+
+	// zero the output and temp
+	vbxx(VMOV, v_out, 0);
+
+	for (int i = 1; i < 8*sizeof(vbx_sp_t); i++){
+		vbxx(VSHL, v_temp, v_in, i);
+
+		// set v_out to the index at which it overflows
+		vbxx(VCMV_FS, v_out, i, v_temp);
+
+		// set index to 0 if overflow flag is set
+		vbxx(VCMV_NZ, v_in, 0, v_out);
+	}
+
+	vbx_sync();
+	return VBW_SUCCESS;
+}
+extern "C" int vbw_vec_shl_word(vbx_word_t *v_out, vbx_word_t *v_in, unsigned int vl){
+	return vbw_vec_shl<vbx_word_t>(v_out,v_in,vl);
+}
+extern "C" int vbw_vec_shl_uword(vbx_uword_t *v_out, vbx_uword_t *v_in, unsigned int vl){
+	return vbw_vec_shl<vbx_uword_t>(v_out,v_in,vl);
+}
+extern "C" int vbw_vec_shl_half(vbx_half_t *v_out, vbx_half_t *v_in, unsigned int vl){
+	return vbw_vec_shl<vbx_half_t>(v_out,v_in,vl);
+}
+extern "C" int vbw_vec_shl_uhalf(vbx_uhalf_t *v_out, vbx_uhalf_t *v_in, unsigned int vl){
+	return vbw_vec_shl<vbx_uhalf_t>(v_out,v_in,vl);
+}
+extern "C" int vbw_vec_shl_byte(vbx_byte_t *v_out, vbx_byte_t *v_in, unsigned int vl){
+	return vbw_vec_shl<vbx_byte_t>(v_out,v_in,vl);
+}
+extern "C" int vbw_vec_shl_ubyte(vbx_ubyte_t *v_out, vbx_ubyte_t *v_in, unsigned int vl){
+	return vbw_vec_shl<vbx_ubyte_t>(v_out,v_in,vl);
+}

--- a/examples/software/lib/vbxware/vbw_vec_shl.h
+++ b/examples/software/lib/vbxware/vbw_vec_shl.h
@@ -1,0 +1,54 @@
+/* VECTORBLOX MXP SOFTWARE DEVELOPMENT KIT
+ *
+ * Copyright (C) 2012-2018 VectorBlox Computing Inc., Vancouver, British Columbia, Canada.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ *     * Neither the name of VectorBlox Computing Inc. nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This agreement shall be governed in all respects by the laws of the Province
+ * of British Columbia and by the laws of Canada.
+ *
+ * This file is part of the VectorBlox MXP Software Development Kit.
+ *
+ */
+
+#ifndef VBW_VEC_SHL_H
+#define VBW_VEC_SHL_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int vbw_vec_shl_word(vbx_word_t *v_out, vbx_word_t *v_in, unsigned int vl);
+int vbw_vec_shl_uword(vbx_uword_t *v_out, vbx_uword_t *v_in, unsigned int vl);
+int vbw_vec_shl_half(vbx_half_t *v_out, vbx_half_t *v_in, unsigned int vl);
+int vbw_vec_shl_uhalf(vbx_uhalf_t *v_out, vbx_uhalf_t *v_in, unsigned int vl);
+int vbw_vec_shl_byte(vbx_byte_t *v_out, vbx_byte_t *v_in, unsigned int vl);
+int vbw_vec_shl_ubyte(vbx_ubyte_t *v_out, vbx_ubyte_t *v_in, unsigned int vl);
+
+#ifdef __cplusplus
+}
+#endif
+#endif //VBW_VEC_ADD_H


### PR DESCRIPTION
**PROBLEM**:
The overflow flag is not consistently set upon a left shift operation that results in an overflow.

**TEST SETUP**:
The test uses pseudo-random input values. MXP is then used to shift the input by increasing amounts (i.e. 1, 2, 3, etc) until the overflow flag is set. This is detected by conditionally moving the shift size into the output vector if the left shift operation causes the overflow flag to be set. To verify this behaviour, the vector output is then compared with the scalar test output. The scalar test determines the shift size by finding the 1-indexed position of the highest set bit (e.g. 1 for 0x80, and 8 for 0x01, if the datatype is unsigned byte). In the case of 0x01, the input would need to be shifted left by 8 in order to trigger an overflow.

**RESULTS**:
- SIMULATOR: does not generate the overflow flag correctly, regardless of datatype.
    - For unsigned datatypes, it cannot detect an overflow for an input of 1 (i.e. 0x01 for byte, 0x0001 for halfword, 0x00000001 for word) of the whole number is shifted out. All other inputs generate the correct result (simulator only).
    - For signed datatypes, the behaviour of `CMV_FS` is undefined (per the reference), however the simulator will consistently return 7 for byte-size input, 15 for halfwords, and 31 for words, which differs from the actual hardware behaviour.
- HARDWARE: does not generate the overflow flag correctly, regardless of datatype.
    - For unsigned datatypes, it cannot detect an overflow for an input of 1 or 2 (i.e. 0x01 or 0x02, with the appropriate number of leading zeroes per datatype). All other inputs generate the correct result.
    - For signed datatypes, the reference does not define the behaviour for `CMV_FS`, however the hardware can correctly detect an overflow for positive inputs, including those that the unsigned version cannot. It does not detect overflow correctly for negative inputs.